### PR TITLE
Modernize "Tax Code" definition

### DIFF
--- a/plan.cftemplate
+++ b/plan.cftemplate
@@ -793,7 +793,7 @@ This is a plan for ""Company"", [Company Name], a Delaware corporation, to grant
         A corporation becomes a <Subsidiary> after this plan is adopted if it meets this definition.
 
         \\
-        ""Tax Code"" means the Internal Revenue Code of 1986.
+        ""Tax Code"" means the Internal Revenue Code, which is Title 26 of the United States Code.
 
         \\
         ""Ten Percent Holder"" means a person who owns stock representing more than ten percent of the voting power of all classes of stock of the <Company>, any <Parent>, or any <Subsidiary>, on the day an <Award> is granted.


### PR DESCRIPTION
We want today's tax code, not the code as it was enacted in 1986. This seems less stuffy, and more useful, than "as amended".
